### PR TITLE
Bumping this dependency b/c of failed docker build https://github.com…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN printf "https://dl-cdn.alpinelinux.org/alpine/edge/community/\nhttps://dl-cd
     && apk add --update --no-cache \
       git \
       py3-gitpython==3.1.27-r0 \
-      py3-pygithub==1.55-r0 \
+      py3-pygithub==1.56-r0 \
       py3-semver==2.13.0-r2 \
     && rm -rf /etc/apk/cache \
     && git config --global --add safe.directory /github/workspace


### PR DESCRIPTION
Bumping this dependency b/c of failed docker build for auto-tagger: https://github.com/RueLaLa/tfmod-infra-akamai-property/actions/runs/3250846981/jobs/5335063591

```
   ERROR: unable to select packages:
    py3-pygithub-1.56-r0:
      breaks: world[py3-pygithub=1.55-r0]
```

I was able to reproduce the error on my local. Bumping py3-pygithub to 1.56 alows `docker build .` to run without error.